### PR TITLE
Fix typo

### DIFF
--- a/web/app/fr/gospeak/web/pages/published/partials/container.scala.html
+++ b/web/app/fr/gospeak/web/pages/published/partials/container.scala.html
@@ -42,7 +42,7 @@
         <p>
             <b>Gospeak</b> is an
             <a href="https://github.com/loicknuchel/gospeak" target="_blank">Open Source project</a>,
-            feel free to create an issue if you think about any possible improvment :)
+            feel free to create an issue if you think about any possible improvement :)
         </p>
     </footer>
 }


### PR DESCRIPTION
It seems there are 2 places with the typo (see https://github.com/loicknuchel/gospeak/pull/107)

Not sure if this one should be invoking the footer partial...