### PR TITLE
Fix typo plateform in index.scala.html

### DIFF
--- a/web/app/gospeak/web/pages/published/index.scala.html
+++ b/web/app/gospeak/web/pages/published/index.scala.html
@@ -13,7 +13,7 @@
             <div class="col-lg-5">
                 <h1 class="display-4 font-size-md-down-5 mb-3">Introducing Gospeak</h1>
                 <p>
-                    A plateform for <strong class="js-typed text-primary" data-strings="speakers.,organizers.,attendees."></strong><br>
+                    A platform for <strong class="js-typed text-primary" data-strings="speakers.,organizers.,attendees."></strong><br>
                     An Open Source project to helps organizers to find speakers.
                 </p>
 


### PR DESCRIPTION
I'm not an English native speaker but I guess it's a typo